### PR TITLE
Increase sensitivity of output

### DIFF
--- a/project.yaml
+++ b/project.yaml
@@ -26,7 +26,7 @@ actions:
       --plot FALSE
     needs: [extract]
     outputs:
-      moderately_sensitive:
+      highly_sensitive:
         feather: output/km_estimates/*.feather
         #png: output/km_estimates/*.png
 


### PR DESCRIPTION
The km action was failing with a validation error. I think this is because feather files must now be written to L3, and not L4, because it's hard to interrogate them. Increasing the sensitivity of the output from `moderately_sensitive` to `highly_sensitive` addresses the validation error.