### PR TITLE
Fix potential race condition

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,6 +6,8 @@ on:
     branches:
       - main
 
+concurrency: tag-new-version
+
 jobs:
   test-integration:
     runs-on: ubuntu-latest


### PR DESCRIPTION
If two commits are merged to `main`, each will trigger a separate run of the CI workflow. If, for some reason, the later commit's run completes first, then the later commit will be tagged with the next version number. The earlier commit, whose run completes second, will also be tagged with the next version number, but the earlier commit's version number will be greater than the later commit's version number, which is very confusing.

This is known as a race condition. To prevent it, we ensure that runs are executed in sequence. GitHub doesn't queue runs, so in the above example (and assuming the two commits aren't pushed at the same time), the later commit's run will cancel the earlier commit's run. The next version number will incorporate changes introduced by the later commit and the earlier commit; it's just that these changes won't be represented by different version numbers.

For more information, see:
https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#concurrency