### PR TITLE
Rename concurrency group

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,7 +6,7 @@ on:
     branches:
       - main
 
-concurrency: tag-new-version
+concurrency: tag-new-version-group
 
 jobs:
   test-integration:


### PR DESCRIPTION
Giving the concurrency group the same name as a job is confusing, especially when the concurrency group applies to the workflow. Thanks for pointing this out, @alarthast. Naming things is hard, so we rename the concurrency group by adding the suffix "-group".

---

Also, a correction: in 7bbff4e I said that GitHub doesn't queue runs. I was mistaken: a workflow concurrency group can have a queue of one. In other words, two instances of a workflow in the same concurrency group are permitted: the first is _running_ and the second is _pending_. [The docs][1] are not as clear as they could be, because "running" has both a specific meaning (the _running_ state) and a general meaning (the _running_ state and the _pending_ state could both be described as _running_). In addition, the docs for workflow concurrency (`concurrency`) also describe job concurrency (`jobs.<job_id>.concurrency`).

[1]: https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#concurrency